### PR TITLE
add graceful shutdown

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"flag"
-	"fmt"
-	"log"
-	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -76,26 +73,12 @@ func main() {
 		models: data.NewModel(db, es),
 	}
 
-	srv := &http.Server{
-		Addr: fmt.Sprintf(":%d", cfg.port),
-		Handler: app.routes(),
-		// Create a new GO log.Logger instance with the log.New() function, passing in
-		// our custom Logger as the first parameter. The "" and 0 indicate that the
-		// log.Logger instance should not use a prefix or any flags.
-		ErrorLog: log.New(logger, "", 0),
-		IdleTimeout: time.Minute,
-		ReadTimeout: 10 * time.Second,
-		WriteTimeout: 10 * time.Second,
+	// Call app.serve() to start the server
+	err = app.serve()
+	if err != nil {
+		logger.PrintFatal(err, nil)
 	}
 
-	logger.PrintInfo("starting server", map[string]string{
-		"addr": srv.Addr,
-		"env": cfg.env,
-	})
-
-	err = srv.ListenAndServe()
-
-	logger.PrintFatal(err, nil)
 }
 
 // The openDB() function returns a sql.DB connection pool

--- a/cmd/api/server.go
+++ b/cmd/api/server.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+func (app *application) serve() error {
+	srv := &http.Server{
+		Addr: fmt.Sprintf(":%d", app.config.port),
+		Handler: app.routes(),
+		// Create a new GO log.Logger instance with the log.New() function, passing in
+		// our custom Logger as the first parameter. The "" and 0 indicate that the
+		// log.Logger instance should not use a prefix or any flags.
+		ErrorLog: log.New(app.logger, "", 0),
+		IdleTimeout: time.Minute,
+		ReadTimeout: 10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+	}
+
+	// Create a shutdownError channel. We will use this to receive any errors returned
+	// by the graceful Shutdown() function.
+	shutdownError := make(chan error)
+
+	// Start a background goroutine
+	go func(){
+		// Create a quit channel which carries os.Signal values
+		quit := make(chan os.Signal, 1)
+
+		// Use signal.Notify() to listen for incoming SIGINT and SIGTEM signals and
+		// relay them to the quit channel. Any other signals will not be caught by
+		// signal.Notify() and will retain their default behaviour
+		signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+
+		// Read the signal from the quit channel. This code will block until a signal is
+		// received
+		s := <-quit
+
+		// Log a message. Notice that we also
+		// call the String() method on the signal to get the signal name and include it
+		// in the log entry properties
+		app.logger.PrintInfo("shutting down server", map[string]string{
+			"signal": s.String(),
+		})
+
+		// Create a context with a 5-second timeout.
+		ctx, cancel := context.WithTimeout(context.Background(), 5 * time.Second)
+		defer cancel()
+
+		// Call Shutdown() on our server, passing in the context we just made.
+		// Shutdown() will return nil if the graceful shutdown was successful, or an
+		// error (which may happen because of a problem closing listeners, or
+		// because the shutdown didn't complete before the 5-second context deadline is hit).
+		// We relay this return value to the shutdownError channel
+		shutdownError <- srv.Shutdown(ctx)
+	}()
+
+	app.logger.PrintInfo("starting server", map[string]string{
+		"addr": srv.Addr,
+		"env": app.config.env,
+	})
+
+	// Calling Shutdown() on our server will cause ListenAndServe() to immediately
+	// return a http.ErrServerClosed error. So if we see this error, it is actually a
+	// good thing and an indication that the graceful shutdown has started. So we check
+	// specifically for this, only returning the error if it is NOT http.ErrServerClosed
+	err := srv.ListenAndServe()
+	if !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+
+	// Otherwise, we wait to receive the return value from Shutdown() on the
+	// shutdownError channel. If return value is an error, we know that there was a
+	// problem with the graceful shutdown and we return the error.
+	err = <-shutdownError
+	if err != nil {
+		return err
+	}
+
+	// At this point we know that graceful shutdown completed successfully and we
+	// log a "stopped server" message.
+	app.logger.PrintInfo("stopped server", map[string]string{
+		"addr": srv.Addr,
+	})
+
+
+	return nil
+}


### PR DESCRIPTION
Graceful shutdown to shutdown server appropriately. Application will be close all idle connection, wait flight request to finished, give client meaningful error response. All of these operation must be done in 5 seconds otherwise graceful shutdown will be return an error.